### PR TITLE
feat: add new test cases for process statement of accounts

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/test_process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/test_process_statement_of_accounts.py
@@ -4,7 +4,7 @@
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import add_days, getdate, today
+from frappe.utils import add_days, getdate, today, add_months
 
 from erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts import (
 	get_statement_dict,
@@ -83,6 +83,70 @@ class TestProcessStatementOfAccounts(AccountsTestMixin, FrappeTestCase):
 	def check_ageing_summary(self, ageing, expected_ageing):
 		for age_range in expected_ageing:
 			self.assertEqual(expected_ageing[age_range], ageing.get(age_range))
+	
+	def test_validate_sets_default_values(self):
+		process_soa = create_process_soa(
+			name="_Test Process SOA",
+			report="Accounts Receivable",
+			subject="",
+			body="",
+			pdf_name=""
+		)
+
+		process_soa.validate()
+
+		assert process_soa.subject == "Statement Of Accounts for {{ customer.customer_name }}"
+		assert process_soa.body == (
+			"Hello {{ customer.customer_name }},<br>"
+			"PFA your Statement Of Accounts until {{ doc.posting_date }}."
+		)
+		assert process_soa.pdf_name == "{{ customer.customer_name }}"
+
+
+	def test_throws_when_no_customers(self):
+		doc = frappe.new_doc("Process Statement Of Accounts")
+		doc.report = "General Ledger"
+		doc.enable_auto_email = 0
+		
+		with self.assertRaises(frappe.ValidationError):
+			doc.validate()
+
+	def test_auto_email_sets_dates(self):
+		start_date = today()
+		doc = create_process_soa(
+			name="_Test Process SOA",
+			report="Accounts Receivable",
+			enable_auto_email=1,
+			from_date=start_date
+		)
+		doc.validate()
+		assert doc.to_date == start_date
+		assert doc.from_date == add_months(start_date, -1)
+
+	def test_body_varies_with_report_type(self):
+		doc = create_process_soa(
+			name="_Test Process SOA",
+			report="Accounts Receivable",
+			body=""
+		)
+		doc.validate()
+		assert doc.body == (
+			"Hello {{ customer.customer_name }},<br>"
+			"PFA your Statement Of Accounts until {{ doc.posting_date }}."
+		)
+
+	def test_general_ledger_body(self):
+		doc = create_process_soa(
+			name="_Test Process SOA",
+			report="General Ledger",
+			body=""
+		)
+		doc.validate()
+		assert doc.body == (
+			"Hello {{ customer.customer_name }},<br>"
+			"PFA your Statement Of Accounts from {{ doc.from_date }} to {{ doc.to_date }}."
+		)
+
 
 	def tearDown(self):
 		frappe.db.rollback()


### PR DESCRIPTION
**Test Cases for Process Statement of Accounts Doctype**
test_validate_sets_default_values
- Verifies that when subject, body, and pdf_name are empty, validate() correctly assigns default values for an "Accounts Receivable" report.

test_throws_when_no_customers
- Ensures that validate() raises a frappe.ValidationError if no customers are linked.

 test_auto_email_sets_dates
- Checks that when auto email is enabled, validate() automatically sets to_date to the given from_date and from_date to one month before.

test_body_varies_with_report_type
- Confirms that for an "Accounts Receivable" report, the default body message matches the correct template format.

test_general_ledger_body
- Ensures that for a "General Ledger" report, the default body message includes both from_date and to_date in the template.